### PR TITLE
Scroll to first matched view holder

### DIFF
--- a/kakao/src/main/kotlin/com/agoda/kakao/Actions.kt
+++ b/kakao/src/main/kotlin/com/agoda/kakao/Actions.kt
@@ -274,7 +274,7 @@ interface RecyclerActions : ScrollableActions {
      * @param viewBuilder Builder that will be used to match view to scroll
      */
     fun scrollTo(viewBuilder: ViewBuilder.() -> Unit) {
-        scrollTo(ViewBuilder().apply(viewBuilder).getViewMatcher())
+        scrollTo(ViewBuilder().apply { withIndex(0, viewBuilder) }.getViewMatcher())
     }
 
     /**


### PR DESCRIPTION
Right now we scroll automatically for any item accessed inside recycler view. The problem starts, when we access it via custom matcher/view builder. In that case, it is possible to stumble into multiple matching view exception, thus scrolling will not work.
This PR solves this issue and tries to scroll to first matched view holder.