### PR TITLE
Add withContentDescription with String identifier to Builders

### DIFF
--- a/kakao/src/main/kotlin/com/agoda/kakao/Builders.kt
+++ b/kakao/src/main/kotlin/com/agoda/kakao/Builders.kt
@@ -174,6 +174,15 @@ class ViewBuilder {
     }
 
     /**
+     * Matches the view with given content description
+     *
+     * @param resourceId Resource id of content description to match
+     */
+    fun withContentDescription(resourceId: Int) {
+        viewMatchers.add(ViewMatchers.withContentDescription(resourceId))
+    }
+
+    /**
      * Matches the view which has parent with given matcher
      *
      * @param function ViewBuilder which will result in parent matcher

--- a/kakao/src/main/kotlin/com/agoda/kakao/Builders.kt
+++ b/kakao/src/main/kotlin/com/agoda/kakao/Builders.kt
@@ -178,7 +178,7 @@ class ViewBuilder {
      *
      * @param resourceId Resource id of content description to match
      */
-    fun withContentDescription(resourceId: Int) {
+    fun withContentDescription(@StringRes resourceId: Int) {
         viewMatchers.add(ViewMatchers.withContentDescription(resourceId))
     }
 


### PR DESCRIPTION
Fixes #72 

Only a simple wrapper is needed to support string resource identifier as matcher.

To use this:
```
val view: KView = KView {
    withContentDescription(R.string.my_content_description)
}
```