### PR TITLE
Add swipeable actions to recycler actions

### DIFF
--- a/kakao/src/main/kotlin/com/agoda/kakao/Actions.kt
+++ b/kakao/src/main/kotlin/com/agoda/kakao/Actions.kt
@@ -1,7 +1,7 @@
 package com.agoda.kakao
 
-import android.support.design.widget.BottomNavigationView
 import android.net.Uri
+import android.support.design.widget.BottomNavigationView
 import android.support.design.widget.TabLayout
 import android.support.test.espresso.UiController
 import android.support.test.espresso.ViewAction
@@ -17,7 +17,10 @@ import android.support.test.espresso.web.sugar.Web
 import android.support.test.espresso.web.webdriver.DriverAtoms
 import android.support.v4.widget.SwipeRefreshLayout
 import android.support.v7.widget.RecyclerView
-import android.view.*
+import android.view.Gravity
+import android.view.InputDevice
+import android.view.MotionEvent
+import android.view.View
 import android.widget.*
 import org.hamcrest.Description
 import org.hamcrest.Matcher
@@ -311,9 +314,10 @@ interface ScrollableActions : BaseActions {
  * Provides ScrollableActions implementation for RecyclerView
  *
  * @see ScrollableActions
+ * @see SwipeableActions
  * @see RecyclerView
  */
-interface RecyclerActions : ScrollableActions {
+interface RecyclerActions : ScrollableActions, SwipeableActions {
     override fun scrollToStart() {
         view.perform(RecyclerViewActions.scrollToPosition<RecyclerView.ViewHolder>(0))
     }

--- a/kakao/src/main/kotlin/com/agoda/kakao/Actions.kt
+++ b/kakao/src/main/kotlin/com/agoda/kakao/Actions.kt
@@ -394,9 +394,10 @@ interface RecyclerActions : ScrollableActions, SwipeableActions {
  * Provides ScrollableActions implementation for ScrollView
  *
  * @see ScrollableActions
+ * @see SwipeableActions
  * @see ScrollView
  */
-interface ScrollViewActions : ScrollableActions {
+interface ScrollViewActions : ScrollableActions, SwipeableActions {
     override fun scrollToStart() {
         view.perform(object : ViewAction {
             override fun getDescription() = "Scroll ScrollView to start"


### PR DESCRIPTION
I was testing some functionality where I was using the scroll state
changed listener of the recyclerview to do a certain action. The scroll*
functions do not trigger a state change since these immediately scroll
to a certain position. The swiping functions allows you to emulate the
action of dragging with your finger across the screen, however these
were not available on the recycler view.