### PR TITLE
Make hasSize() error message a little bit more descriptive

### DIFF
--- a/kakao/src/main/kotlin/com/agoda/kakao/Matchers.kt
+++ b/kakao/src/main/kotlin/com/agoda/kakao/Matchers.kt
@@ -178,7 +178,7 @@ class ProgressMatcher(private val value: Int) : BoundedMatcher<View, ProgressBar
 
 /**
  * Matcher of value rating of given matcher
- * 
+ *
  * @param value of rating that matched the view which is RatingBar
  */
 class RatingBarMatcher(private val value: Float) : BoundedMatcher<View, RatingBar>(RatingBar::class.java) {
@@ -190,30 +190,48 @@ class RatingBarMatcher(private val value: Float) : BoundedMatcher<View, RatingBa
 }
 
 /**
- * Matches RecyclerView with count of childs
+ * Matches RecyclerView with count of children
  *
- * @param size of childs count in RecyclerView
+ * @param size of children count in RecyclerView
  */
 class RecyclerViewAdapterSizeMatcher(private val size: Int) : BoundedMatcher<View, RecyclerView>(RecyclerView::class.java) {
-    override fun matchesSafely(view: RecyclerView?) = view?.adapter?.let {
-        it.itemCount == size } ?: false
+
+    private var itemCount: Int = 0
+
+    override fun matchesSafely(view: RecyclerView) = run {
+        itemCount = view.adapter?.itemCount ?: 0
+        itemCount == size
+    }
 
     override fun describeTo(description: Description) {
-        description.appendText("recycle view size is: $size")
+        description
+                .appendText("RecyclerView with ")
+                .appendValue(size)
+                .appendText(" item(s), but got with ")
+                .appendValue(itemCount)
     }
 }
 
 /**
- * Matches ListView with count of childs
+ * Matches ListView with count of children
  *
- * @param size of childs count in ListView
+ * @param size of children count in ListView
  */
 class ListViewViewAdapterSizeMatcher(private val size: Int) : BoundedMatcher<View, ListView>(ListView::class.java) {
-    override fun matchesSafely(view: ListView?) = view?.adapter?.let {
-        it.count == size } ?: false
+
+    private var itemCount: Int = 0
+
+    override fun matchesSafely(view: ListView) = run {
+        itemCount = view.adapter?.count ?: 0
+        itemCount == size
+    }
 
     override fun describeTo(description: Description) {
-        description.appendText("recycle view size is: $size")
+        description
+                .appendText("ListView with ")
+                .appendValue(size)
+                .appendText(" item(s), but got with ")
+                .appendValue(itemCount)
     }
 }
 


### PR DESCRIPTION
Before:

```
Expected: recycle view size is: 9
Got: "RecyclerView{id=2131230836, res-name=recycler_view, visibility=VISIBLE, width=1080, height=1584, has-focus=true, has-focusable=true, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=true, is-layout-requested=false, is-selected=false, layout-params=android.widget.FrameLayout$LayoutParams@7ae3580, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=0.0, child-count=7}"
```

After: 

```
Expected: RecyclerView with <9> item(s), but got with <10>
Got: "RecyclerView{id=2131230836, res-name=recycler_view, visibility=VISIBLE, width=1080, height=1584, has-focus=true, has-focusable=true, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=true, is-layout-requested=false, is-selected=false, layout-params=android.widget.FrameLayout$LayoutParams@8cf4203, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=0.0, child-count=7}"
```

The first idea was to make it like:

```
Expected: <9>
Got: <10>
```

but it needs much more effort - need to create a matcher from scratch, so I think this solution is acceptable as well
