### PR TITLE
Create AutoCompleteTextView sample

### DIFF
--- a/sample/src/androidTest/kotlin/com/agoda/sample/AutoCompleteTest.kt
+++ b/sample/src/androidTest/kotlin/com/agoda/sample/AutoCompleteTest.kt
@@ -1,0 +1,63 @@
+package com.agoda.sample
+
+import android.support.test.rule.ActivityTestRule
+import android.support.test.runner.AndroidJUnit4
+import com.agoda.sample.screen.AutoCompleteActivityScreen
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AutoCompleteTest {
+    @Rule
+    @JvmField
+    val rule = ActivityTestRule(AutoCompleteActivity::class.java)
+
+    val screen = AutoCompleteActivityScreen()
+
+    @Test
+    fun testContentItemsListView() {
+        screen {
+            input {
+                isDisplayed()
+                typeText("Title")
+            }
+
+            list {
+                inRoot {
+                    isPlatformPopup()
+                }
+
+                isVisible()
+                hasSize(10)
+
+                firstChild<AutoCompleteActivityScreen.Item> {
+                    isVisible()
+                    text {
+                        hasText("Title 1")
+                    }
+                }
+
+                lastChild<AutoCompleteActivityScreen.Item> {
+                    isVisible()
+                    text { hasText("Title 10") }
+                }
+
+                childWith<AutoCompleteActivityScreen.Item> {
+                    isInstanceOf(String::class.java)
+                    equals("Title 5")
+                } perform {
+                    text {
+                        isDisplayed()
+                        click()
+                    }
+                }
+            }
+
+            input {
+                isDisplayed()
+                hasText("Title 5")
+            }
+        }
+    }
+}

--- a/sample/src/androidTest/kotlin/com/agoda/sample/TestActivityTest.kt
+++ b/sample/src/androidTest/kotlin/com/agoda/sample/TestActivityTest.kt
@@ -42,8 +42,12 @@ class TestActivityTest {
                 hasAnyTag("test_tag", "non_test_tag")
             }
 
-            button {
-                hasText("BUTTON")
+            recycler {
+                hasText("RECYCLER")
+            }
+
+            autoComplete {
+                hasText("AUTO_COMPLETE")
             }
 
             ratingbar {

--- a/sample/src/androidTest/kotlin/com/agoda/sample/screen/AutoCompleteActivityScreen.kt
+++ b/sample/src/androidTest/kotlin/com/agoda/sample/screen/AutoCompleteActivityScreen.kt
@@ -1,0 +1,25 @@
+package com.agoda.sample.screen
+
+import android.support.test.espresso.DataInteraction
+import android.widget.ListView
+import com.agoda.kakao.KAdapterItem
+import com.agoda.kakao.KEditText
+import com.agoda.kakao.KListView
+import com.agoda.kakao.KTextView
+import com.agoda.kakao.Screen
+import com.agoda.sample.R
+
+class AutoCompleteActivityScreen : Screen<AutoCompleteActivityScreen>() {
+
+    val input = KEditText {
+        withId(R.id.auto_complete_view)
+    }
+
+    val list = KListView(
+            builder = { isInstanceOf(ListView::class.java) },
+            itemTypeBuilder = { itemType(::Item) })
+
+    class Item(i: DataInteraction) : KAdapterItem<Item>(i) {
+        val text = KTextView(i) { withId(android.R.id.text1) }
+    }
+}

--- a/sample/src/androidTest/kotlin/com/agoda/sample/screen/AutoCompleteActivityScreen.kt
+++ b/sample/src/androidTest/kotlin/com/agoda/sample/screen/AutoCompleteActivityScreen.kt
@@ -10,7 +10,6 @@ import com.agoda.kakao.Screen
 import com.agoda.sample.R
 
 class AutoCompleteActivityScreen : Screen<AutoCompleteActivityScreen>() {
-
     val input = KEditText {
         withId(R.id.auto_complete_view)
     }
@@ -20,6 +19,6 @@ class AutoCompleteActivityScreen : Screen<AutoCompleteActivityScreen>() {
             itemTypeBuilder = { itemType(::Item) })
 
     class Item(i: DataInteraction) : KAdapterItem<Item>(i) {
-        val text = KTextView(i) { withId(android.R.id.text1) }
+        val text = KTextView(i) { withId(R.id.text) }
     }
 }

--- a/sample/src/androidTest/kotlin/com/agoda/sample/screen/TestActivityScreen.kt
+++ b/sample/src/androidTest/kotlin/com/agoda/sample/screen/TestActivityScreen.kt
@@ -6,7 +6,8 @@ import com.agoda.kakao.*
 open class TestActivityScreen : Screen<TestActivityScreen>() {
     val content: KView = KView { withId(R.id.content) }
     val map: KView = KView { withId(R.id.map) }
-    val button: KButton = KButton { withId(R.id.button) }
+    val recycler: KButton = KButton { withId(R.id.recycler) }
+    val autoComplete: KButton = KButton { withId(R.id.auto_complete) }
     val snackbarButton: KButton = KButton { withId(R.id.snackbar_button) }
 
     val textViewLarge: KTextView = KTextView {

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -48,6 +48,11 @@
             android:label="Intent Activity"
             android:theme="@style/AppTheme" />
 
+        <activity
+            android:name=".AutoCompleteActivity"
+            android:label="Autocomplete Activity"
+            android:theme="@style/AppTheme" />
+
     </application>
 
 </manifest>

--- a/sample/src/main/kotlin/com/agoda/sample/AutoCompleteActivity.kt
+++ b/sample/src/main/kotlin/com/agoda/sample/AutoCompleteActivity.kt
@@ -11,7 +11,7 @@ class AutoCompleteActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_auto_complete)
 
-        val adapter = ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, android.R.id.text1,
+        val adapter = ArrayAdapter<String>(this, R.layout.item_autocomplete, R.id.text,
                 listOf("Title 1", "Title 2", "Title 3", "Title 4", "Title 5",
                         "Title 6", "Title 7", "Title 8", "Title 9", "Title 10"))
 

--- a/sample/src/main/kotlin/com/agoda/sample/AutoCompleteActivity.kt
+++ b/sample/src/main/kotlin/com/agoda/sample/AutoCompleteActivity.kt
@@ -1,0 +1,21 @@
+package com.agoda.sample
+
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import android.widget.ArrayAdapter
+import android.widget.AutoCompleteTextView
+
+class AutoCompleteActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_auto_complete)
+
+        val adapter = ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, android.R.id.text1,
+                listOf("Title 1", "Title 2", "Title 3", "Title 4", "Title 5",
+                        "Title 6", "Title 7", "Title 8", "Title 9", "Title 10"))
+
+        val autocomplete = findViewById<AutoCompleteTextView>(R.id.auto_complete_view)
+        autocomplete.setAdapter(adapter)
+    }
+}

--- a/sample/src/main/kotlin/com/agoda/sample/TestActivity.kt
+++ b/sample/src/main/kotlin/com/agoda/sample/TestActivity.kt
@@ -9,7 +9,7 @@ import android.widget.Button
 import android.widget.ImageView
 import android.widget.SeekBar
 
-class TestActivity: AppCompatActivity() {
+class TestActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_test)
@@ -19,8 +19,12 @@ class TestActivity: AppCompatActivity() {
         super.onResume()
         findViewById<ImageView>(R.id.map).tag = "test_tag"
 
-        findViewById<Button>(R.id.button).setOnClickListener {
+        findViewById<Button>(R.id.recycler).setOnClickListener {
             startActivity(Intent(this, RecyclerActivity::class.java))
+        }
+
+        findViewById<Button>(R.id.auto_complete).setOnClickListener {
+            startActivity(Intent(this, AutoCompleteActivity::class.java))
         }
 
         findViewById<Button>(R.id.web_button).setOnClickListener {

--- a/sample/src/main/res/layout/activity_auto_complete.xml
+++ b/sample/src/main/res/layout/activity_auto_complete.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoCompleteTextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/auto_complete_view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:completionThreshold="3"
+    tools:ignore="LabelFor"/>

--- a/sample/src/main/res/layout/activity_test.xml
+++ b/sample/src/main/res/layout/activity_test.xml
@@ -31,10 +31,16 @@
         android:layout_height="100dp" />
 
     <Button
-        android:id="@+id/button"
+        android:id="@+id/recycler"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="BUTTON" />
+        android:text="RECYCLER" />
+
+    <Button
+        android:id="@+id/auto_complete"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="AUTO_COMPLETE" />
 
     <Button
             android:id="@+id/web_button"

--- a/sample/src/main/res/layout/item_autocomplete.xml
+++ b/sample/src/main/res/layout/item_autocomplete.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" >
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+</LinearLayout>


### PR DESCRIPTION
With reference to issue #42 this provides a sample demo for the `AutoCompleteTextView` usage with a `DecorPopupView` which is currently unsuccessful.

Stack trace indicates that the platform popup view is not present in the view hierarchy, or that assertions are being made against the wrong window.

```
android.support.test.espresso.NoMatchingViewException: No views in hierarchy found matching: (an instance of android.widget.ListView)

View Hierarchy:
+>DecorView{id=-1, visibility=VISIBLE, width=1080, height=1920, has-focus=true, has-focusable=true, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params={(0,0)(fillxfill) ty=BASE_APPLICATION wanim=0x10302f8
fl=LAYOUT_IN_SCREEN LAYOUT_INSET_DECOR SPLIT_TOUCH HARDWARE_ACCELERATED DRAWS_SYSTEM_BAR_BACKGROUNDS
pfl=FORCE_DRAW_STATUS_BAR_BACKGROUND}, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=0.0, child-count=3}
|
+->LinearLayout{id=-1, visibility=VISIBLE, width=1080, height=1813, has-focus=true, has-focusable=true, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params=android.widget.FrameLayout$LayoutParams@db771, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=0.0, child-count=2}
|
+-->ViewStub{id=16908682, res-name=action_mode_bar_stub, visibility=GONE, width=0, height=0, has-focus=false, has-focusable=false, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=true, is-selected=false, layout-params=android.widget.LinearLayout$LayoutParams@621b956, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=0.0}
|
+-->FrameLayout{id=-1, visibility=VISIBLE, width=1080, height=1760, has-focus=true, has-focusable=true, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params=android.widget.LinearLayout$LayoutParams@59ad6c4, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=53.0, child-count=1}
|
+--->ActionBarOverlayLayout{id=2131230774, res-name=decor_content_parent, visibility=VISIBLE, width=1080, height=1760, has-focus=true, has-focusable=true, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params=android.widget.FrameLayout$LayoutParams@ff559ad, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=0.0, child-count=2}
|
+---->ContentFrameLayout{id=16908290, res-name=content, visibility=VISIBLE, width=1080, height=1635, has-focus=true, has-focusable=true, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params=android.support.v7.widget.ActionBarOverlayLayout$LayoutParams@e9f073, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=125.0, child-count=1}
|
+----->AppCompatAutoCompleteTextView{id=2131230753, res-name=auto_complete_view, visibility=VISIBLE, width=1080, height=100, has-focus=true, has-focusable=true, has-window-focus=true, is-clickable=true, is-enabled=true, is-focused=true, is-focusable=true, is-layout-requested=false, is-selected=false, layout-params=android.widget.FrameLayout$LayoutParams@1269d2e, tag=null, root-is-layout-requested=false, has-input-connection=true, editor-info=[inputType=0x30001 imeOptions=0x40000006 privateImeOptions=null actionLabel=null actionId=0 initialSelStart=5 initialSelEnd=5 initialCapsMode=0x0 hintText=null label=null packageName=null fieldId=0 fieldName=null extras=null hintLocales=null contentMimeTypes=null ], x=0.0, y=0.0, text=Title, input-type=196609, ime-target=true, has-links=false}
|
+---->ActionBarContainer{id=2131230729, res-name=action_bar_container, visibility=VISIBLE, width=1080, height=125, has-focus=false, has-focusable=false, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params=android.support.v7.widget.ActionBarOverlayLayout$LayoutParams@2351165, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=0.0, child-count=2}
|
+----->Toolbar{id=2131230727, res-name=action_bar, visibility=VISIBLE, width=1080, height=125, has-focus=false, has-focusable=false, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params=android.widget.FrameLayout$LayoutParams@5035e3a, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=0.0, child-count=2}
|
+------>AppCompatTextView{id=-1, visibility=VISIBLE, width=447, height=61, has-focus=false, has-focusable=false, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params=android.support.v7.widget.Toolbar$LayoutParams@400faeb, tag=null, root-is-layout-requested=false, has-input-connection=false, x=35.0, y=32.0, text=Autocomplete Activity, input-type=0, ime-target=false, has-links=false}
|
+------>ActionMenuView{id=-1, visibility=VISIBLE, width=0, height=125, has-focus=false, has-focusable=false, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params=android.support.v7.widget.Toolbar$LayoutParams@da0a048, tag=null, root-is-layout-requested=false, has-input-connection=false, x=1080.0, y=0.0, child-count=0}
|
+----->ActionBarContextView{id=2131230735, res-name=action_context_bar, visibility=GONE, width=0, height=0, has-focus=false, has-focusable=false, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=true, is-selected=false, layout-params=android.widget.FrameLayout$LayoutParams@dea5ee1, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=0.0, child-count=0}
|
+->View{id=16908336, res-name=navigationBarBackground, visibility=VISIBLE, width=1080, height=107, has-focus=false, has-focusable=false, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params=android.widget.FrameLayout$LayoutParams@8b92406, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=1813.0}
|
+->View{id=16908335, res-name=statusBarBackground, visibility=VISIBLE, width=1080, height=53, has-focus=false, has-focusable=false, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params=android.widget.FrameLayout$LayoutParams@2725ac7, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=0.0}
|
at dalvik.system.VMStack.getThreadStackTrace(Native Method)
at java.lang.Thread.getStackTrace(Thread.java:1538)
at android.support.test.espresso.base.DefaultFailureHandler.getUserFriendlyError(DefaultFailureHandler.java:90)
at android.support.test.espresso.base.DefaultFailureHandler.handle(DefaultFailureHandler.java:52)
at android.support.test.espresso.ViewInteraction.waitForAndHandleInteractionResults(ViewInteraction.java:312)
at android.support.test.espresso.ViewInteraction.desugaredPerform(ViewInteraction.java:167)
at android.support.test.espresso.ViewInteraction.perform(ViewInteraction.java:110)
at android.support.test.espresso.DataInteraction$DisplayDataMatcher$1.apply(DataInteraction.java:206)
at android.support.test.espresso.DataInteraction$DisplayDataMatcher$1.apply(DataInteraction.java:203)
at android.support.test.espresso.DataInteraction$DisplayDataMatcher.<init>(DataInteraction.java:223)
at android.support.test.espresso.DataInteraction$DisplayDataMatcher.<init>(DataInteraction.java:198)
at android.support.test.espresso.DataInteraction$DisplayDataMatcher.displayDataMatcher(DataInteraction.java:241)
at android.support.test.espresso.DataInteraction.makeTargetMatcher(DataInteraction.java:143)
at android.support.test.espresso.DataInteraction.check(DataInteraction.java:137)
at com.agoda.kakao.KAdapterItem.<init>(Views.kt:830)
at com.agoda.sample.screen.AutoCompleteActivityScreen$Item.<init>(AutoCompleteActivityScreen.kt:22)
at com.agoda.sample.screen.AutoCompleteActivityScreen$list$2$1.invoke(AutoCompleteActivityScreen.kt:20)
at com.agoda.sample.screen.AutoCompleteActivityScreen$list$2$1.invoke(AutoCompleteActivityScreen.kt:12)
at com.agoda.sample.AutoCompleteTest$testContentItemsListView$1$2.invoke(AutoCompleteTest.kt:81)
at com.agoda.sample.AutoCompleteTest$testContentItemsListView$1$2.invoke(AutoCompleteTest.kt:11)
at com.agoda.kakao.KListView.invoke(Views.kt:485)
at com.agoda.sample.AutoCompleteTest$testContentItemsListView$1.invoke(AutoCompleteTest.kt:26)
at com.agoda.sample.AutoCompleteTest$testContentItemsListView$1.invoke(AutoCompleteTest.kt:11)
at com.agoda.kakao.Screen.invoke(Screen.kt:21)
at com.agoda.sample.AutoCompleteTest.testContentItemsListView(AutoCompleteTest.kt:20)
at java.lang.reflect.Method.invoke(Native Method)
at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
at android.support.test.rule.ActivityTestRule$ActivityStatement.evaluate(ActivityTestRule.java:433)
at org.junit.rules.RunRules.evaluate(RunRules.java:20)
at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
at org.junit.runners.Suite.runChild(Suite.java:128)
at org.junit.runners.Suite.runChild(Suite.java:27)
at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:58)
at android.support.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:375)
at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2145)
```

It can also be noted that introducing the following to the `KListView` builder is also unsuccessful.
```
withParent {
    isRoot()
}
```