### PR TITLE
Modify the public API using reified inline "onScreen()" function

### DIFF
--- a/kakao/src/main/kotlin/com/agoda/kakao/screen/Screen.kt
+++ b/kakao/src/main/kotlin/com/agoda/kakao/screen/Screen.kt
@@ -43,5 +43,8 @@ open class Screen<out T: Screen<T>>: ScreenActions {
                 }
             })
         }
+
+        inline fun <reified T : Screen<T>> onScreen(function: T.() -> Unit): T =
+                T::class.java.newInstance().apply { function.invoke(this) }
     }
 }

--- a/sample/src/androidTest/kotlin/com/agoda/sample/AutoCompleteTest.kt
+++ b/sample/src/androidTest/kotlin/com/agoda/sample/AutoCompleteTest.kt
@@ -2,6 +2,7 @@ package com.agoda.sample
 
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
+import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.agoda.sample.screen.AutoCompleteActivityScreen
 import org.junit.Rule
 import org.junit.Test
@@ -13,11 +14,9 @@ class AutoCompleteTest {
     @JvmField
     val rule = ActivityTestRule(AutoCompleteActivity::class.java)
 
-    val screen = AutoCompleteActivityScreen()
-
     @Test
     fun testContentItemsListView() {
-        screen {
+        onScreen<AutoCompleteActivityScreen> {
             input {
                 isDisplayed()
                 typeText("Title")

--- a/sample/src/androidTest/kotlin/com/agoda/sample/IntentActivityTest.kt
+++ b/sample/src/androidTest/kotlin/com/agoda/sample/IntentActivityTest.kt
@@ -2,6 +2,7 @@ package com.agoda.sample
 
 import android.support.test.espresso.intent.rule.IntentsTestRule
 import android.support.test.runner.AndroidJUnit4
+import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.agoda.sample.screen.IntentActivityScreen
 import org.junit.Rule
 import org.junit.Test
@@ -13,11 +14,9 @@ class IntentActivityTest {
     @JvmField
     val rule = IntentsTestRule(IntentActivity::class.java)
 
-    val screen = IntentActivityScreen()
-
     @Test
     fun testContentScreen() {
-        screen {
+        onScreen<IntentActivityScreen> {
             resultText { hasText("No result") }
 
             startActivityButton { click() }

--- a/sample/src/androidTest/kotlin/com/agoda/sample/ListTest.kt
+++ b/sample/src/androidTest/kotlin/com/agoda/sample/ListTest.kt
@@ -2,6 +2,7 @@ package com.agoda.sample
 
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
+import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.agoda.sample.screen.TestListScreen
 import org.junit.Rule
 import org.junit.Test
@@ -13,11 +14,9 @@ class ListTest {
     @JvmField
     val rule = ActivityTestRule(ListActivity::class.java)
 
-    val screen = TestListScreen()
-
     @Test
     fun testContentItemsListView() {
-        screen {
+        onScreen<TestListScreen> {
             list {
                 isVisible()
                 hasSize(10)

--- a/sample/src/androidTest/kotlin/com/agoda/sample/NestedRecyclerTest.kt
+++ b/sample/src/androidTest/kotlin/com/agoda/sample/NestedRecyclerTest.kt
@@ -2,6 +2,7 @@ package com.agoda.sample
 
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
+import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.agoda.sample.screen.TestNestedRecyclerScreen
 import com.agoda.sample.screen.TestNestedRecyclerScreen.NestedItem
 import com.agoda.sample.screen.TestNestedRecyclerScreen.RecyclerItem
@@ -15,11 +16,9 @@ class NestedRecyclerTest {
     @JvmField
     val rule = ActivityTestRule(NestedRecyclerActivity::class.java)
 
-    val screen = TestNestedRecyclerScreen()
-
     @Test
     fun testContentItemsRecyclerView() {
-        screen {
+        onScreen<TestNestedRecyclerScreen> {
             recycler {
                 isVisible()
 

--- a/sample/src/androidTest/kotlin/com/agoda/sample/RecyclerTest.kt
+++ b/sample/src/androidTest/kotlin/com/agoda/sample/RecyclerTest.kt
@@ -2,6 +2,7 @@ package com.agoda.sample
 
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
+import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.agoda.sample.screen.TestRecyclerScreen
 import org.junit.Rule
 import org.junit.Test
@@ -13,11 +14,9 @@ class RecyclerTest {
     @JvmField
     val rule = ActivityTestRule(RecyclerActivity::class.java)
 
-    val screen = TestRecyclerScreen()
-
     @Test
     fun testContentItemsRecyclerView() {
-        screen {
+        onScreen<TestRecyclerScreen> {
             recycler {
                 isVisible()
                 hasSize(10)

--- a/sample/src/androidTest/kotlin/com/agoda/sample/TestActivityTest.kt
+++ b/sample/src/androidTest/kotlin/com/agoda/sample/TestActivityTest.kt
@@ -3,6 +3,7 @@ package com.agoda.sample
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
 import com.agoda.kakao.screen.Screen.Companion.idle
+import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.agoda.sample.screen.TestActivityScreen
 import org.junit.Rule
 import org.junit.Test
@@ -14,11 +15,9 @@ class TestActivityTest {
     @JvmField
     val rule = ActivityTestRule(TestActivity::class.java)
 
-    val screen = TestActivityScreen()
-
     @Test
     fun testContentScreen() {
-        screen {
+        onScreen<TestActivityScreen> {
             content {
                 isVisible()
             }

--- a/sample/src/androidTest/kotlin/com/agoda/sample/TextInputLayoutTest.kt
+++ b/sample/src/androidTest/kotlin/com/agoda/sample/TextInputLayoutTest.kt
@@ -2,6 +2,7 @@ package com.agoda.sample
 
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
+import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.agoda.sample.screen.TextInputLayoutScreen
 import org.junit.Rule
 import org.junit.Test
@@ -13,11 +14,9 @@ class TextInputLayoutTest {
     @JvmField
     val rule = ActivityTestRule(TextInputLayoutActivity::class.java)
 
-    val screen = TextInputLayoutScreen()
-
     @Test
     fun testTextInputLayout() {
-        screen {
+        onScreen<TextInputLayoutScreen> {
             inputLayout {
                 hasCounterMaxLength(50)
                 hasHint("This is the HINT!")

--- a/sample/src/androidTest/kotlin/com/agoda/sample/WebTest.kt
+++ b/sample/src/androidTest/kotlin/com/agoda/sample/WebTest.kt
@@ -3,6 +3,7 @@ package com.agoda.sample
 import android.support.test.espresso.web.webdriver.Locator
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
+import com.agoda.kakao.screen.Screen.Companion.onScreen
 import com.agoda.sample.screen.TestWebScreen
 import org.junit.Rule
 import org.junit.Test
@@ -14,11 +15,9 @@ class WebTest {
     @JvmField
     val rule = ActivityTestRule(WebAcitivty::class.java)
 
-    private val screen = TestWebScreen()
-
     @Test
     fun testWebViewHasTextHelloAndClickLink() {
-        screen {
+        onScreen<TestWebScreen> {
             webView {
                 withElement(Locator.ID, "text") {
                     hasText("Hello")


### PR DESCRIPTION
In version 1 of the API I would need to declare a property in my test for the screen I was using
```kotlin
val screen = MyExampleScreen()

@Test
fun testSomethingImportant() {
    screen {
        ...
    }
}
```
This pull request adds the ability to skip declaring the member variable and utilize the screen directly
```kotlin
@Test
fun testSomethingImportant() {
    onScreen<MyExampleScreen> {
        ...
    }
}
```
The version 1 style is still present to provide backward compatibility.  I also modified the sample tests to utilize this new API.
