### PR TITLE
Add approval for AT

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,9 +102,12 @@ workflows:
   build-deploy:
     jobs:
       - build-job
+      - run-at-approval:
+          type: approval
       - automation-tests-job:
           requires:
             - build-job
+            - run-at-approval
           filters:
             branches:
               ignore: master


### PR DESCRIPTION
When we creating any PR to master it triggering AT tests. Unfortunately we have only 10 runs per day. for that. Firstly n we can improve it through manual approval when it really necessary. @Unlimity 