### PR TITLE
Fix Snackbar compatibility with androidx

### DIFF
--- a/kakao/src/main/kotlin/com/agoda/kakao/text/KSnackbar.kt
+++ b/kakao/src/main/kotlin/com/agoda/kakao/text/KSnackbar.kt
@@ -2,8 +2,6 @@
 
 package com.agoda.kakao.text
 
-import androidx.appcompat.widget.AppCompatButton
-import androidx.appcompat.widget.AppCompatTextView
 import com.agoda.kakao.common.views.KBaseView
 import com.google.android.material.snackbar.Snackbar
 
@@ -15,11 +13,11 @@ import com.google.android.material.snackbar.Snackbar
 class KSnackbar : KBaseView<KSnackbar>({ isInstanceOf(Snackbar.SnackbarLayout::class.java) }) {
     val text = KTextView {
         isDescendantOfA { isInstanceOf(Snackbar.SnackbarLayout::class.java) }
-        isInstanceOf(AppCompatTextView::class.java)
+        withResourceName("snackbar_text")
     }
 
     val action = KButton {
         isDescendantOfA { isInstanceOf(Snackbar.SnackbarLayout::class.java) }
-        isInstanceOf(AppCompatButton::class.java)
+        withResourceName("snackbar_action")
     }
 }

--- a/kakao/src/main/kotlin/com/agoda/kakao/text/KSnackbar.kt
+++ b/kakao/src/main/kotlin/com/agoda/kakao/text/KSnackbar.kt
@@ -13,11 +13,11 @@ import com.google.android.material.snackbar.Snackbar
 class KSnackbar : KBaseView<KSnackbar>({ isInstanceOf(Snackbar.SnackbarLayout::class.java) }) {
     val text = KTextView {
         isDescendantOfA { isInstanceOf(Snackbar.SnackbarLayout::class.java) }
-        withResourceName("snackbar_text")
+        withId(com.google.android.material.R.id.snackbar_text)
     }
 
     val action = KButton {
         isDescendantOfA { isInstanceOf(Snackbar.SnackbarLayout::class.java) }
-        withResourceName("snackbar_action")
+        withId(com.google.android.material.R.id.snackbar_action)
     }
 }


### PR DESCRIPTION
Material Snackbar has stable Ids we should rely on, otherwise it won't work (no AppcompatTextView would be found)