### PR TITLE
Add root view to screens

### DIFF
--- a/kakao/src/main/kotlin/com/agoda/kakao/screen/Screen.kt
+++ b/kakao/src/main/kotlin/com/agoda/kakao/screen/Screen.kt
@@ -29,6 +29,7 @@ open class Screen<out T: Screen<T>>: ScreenActions {
 
     /**
      * The visibility of rootView will be checked when entering the screen
+     * @rootView.isVisible() Will be called after land onScreen<>()
      */
     open var rootView: KBaseView<*>? = null
 

--- a/kakao/src/main/kotlin/com/agoda/kakao/screen/Screen.kt
+++ b/kakao/src/main/kotlin/com/agoda/kakao/screen/Screen.kt
@@ -9,6 +9,7 @@ import androidx.test.espresso.ViewAction
 import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.matcher.ViewMatchers
 import com.agoda.kakao.common.KakaoDslMarker
+import com.agoda.kakao.common.views.KBaseView
 
 /**
  * Container class for UI elements.
@@ -28,6 +29,11 @@ open class Screen<out T: Screen<T>>: ScreenActions {
 
     companion object {
         /**
+         * The visibility of rootView will be checked when entering the screen
+         */
+        var rootView: KBaseView<*>? = null
+
+        /**
          * Idles for given amount of time
          *
          * @param duration Time to idle in milliseconds (1 second by default)
@@ -44,7 +50,9 @@ open class Screen<out T: Screen<T>>: ScreenActions {
             })
         }
 
-        inline fun <reified T : Screen<T>> onScreen(function: T.() -> Unit): T =
-                T::class.java.newInstance().apply { function.invoke(this) }
+        inline fun <reified T : Screen<T>> onScreen(function: T.() -> Unit): T {
+            rootView?.isVisible()
+            return T::class.java.newInstance().apply { function.invoke(this) }
+        }
     }
 }

--- a/kakao/src/main/kotlin/com/agoda/kakao/screen/Screen.kt
+++ b/kakao/src/main/kotlin/com/agoda/kakao/screen/Screen.kt
@@ -27,12 +27,12 @@ open class Screen<out T: Screen<T>>: ScreenActions {
     override val view: ViewInteraction = Espresso.onView(ViewMatchers.isRoot())
     operator fun invoke(function: T.() -> Unit) = function.invoke(this as T)
 
-    companion object {
-        /**
-         * The visibility of rootView will be checked when entering the screen
-         */
-        var rootView: KBaseView<*>? = null
+    /**
+     * The visibility of rootView will be checked when entering the screen
+     */
+    open var rootView: KBaseView<*>? = null
 
+    companion object {
         /**
          * Idles for given amount of time
          *
@@ -51,8 +51,10 @@ open class Screen<out T: Screen<T>>: ScreenActions {
         }
 
         inline fun <reified T : Screen<T>> onScreen(function: T.() -> Unit): T {
-            rootView?.isVisible()
-            return T::class.java.newInstance().apply { function.invoke(this) }
+            return T::class.java
+                    .newInstance()
+                    .also { it.rootView?.isVisible() }
+                    .apply { function.invoke(this) }
         }
     }
 }

--- a/sample/src/androidTest/kotlin/com/agoda/sample/screen/TextInputLayoutScreen.kt
+++ b/sample/src/androidTest/kotlin/com/agoda/sample/screen/TextInputLayoutScreen.kt
@@ -10,4 +10,8 @@ class TextInputLayoutScreen : Screen<TextInputLayoutScreen>() {
     val toggleCounter = KButton { withId(R.id.toggle_counter) }
     val toggleHint = KButton { withId(R.id.toggle_hint) }
     val toggleError = KButton { withId(R.id.toggle_error) }
+
+    init {
+        rootView = inputLayout
+    }
 }


### PR DESCRIPTION
How you know sometimes when we landing on screen we should to check some "onScreen..blahblah....check" 
I have suggestion to add rootView to Screen object and if it necessary you can provide it through declaration

I think that this improvement can reduce boilerplate in some projects 