### PR TITLE
Add test cases for image in RecyclerView

### DIFF
--- a/sample/src/androidTest/kotlin/com/agoda/sample/DrawableRecyclerTest.kt
+++ b/sample/src/androidTest/kotlin/com/agoda/sample/DrawableRecyclerTest.kt
@@ -1,0 +1,54 @@
+package com.agoda.sample
+
+import androidx.core.content.res.ResourcesCompat
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import androidx.test.rule.ActivityTestRule
+import com.agoda.kakao.screen.Screen.Companion.onScreen
+import com.agoda.sample.screen.DrawableRecyclerScreen
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class DrawableRecyclerTest {
+    @Rule
+    @JvmField
+    val rule = ActivityTestRule(DrawableRecyclerActivity::class.java)
+
+    private val appContext get() = rule.activity.applicationContext
+
+    @Test
+    fun matchDrawablesInList() {
+        onScreen<DrawableRecyclerScreen> {
+            list {
+                isVisible()
+                hasSize(3)
+
+                firstChild<DrawableRecyclerScreen.Item> {
+                    isVisible()
+                    imageView {
+                        hasDrawable(R.drawable.ic_android_black_24dp)
+                    }
+                }
+
+                childAt<DrawableRecyclerScreen.Item>(1) {
+                    imageView {
+                        val drawable = ResourcesCompat.getDrawable(
+                            appContext.resources,
+                            R.drawable.ic_sentiment_very_satisfied_black_24dp,
+                            appContext.theme
+                        )
+                        hasDrawable(drawable!!)
+                    }
+                }
+
+                childAt<DrawableRecyclerScreen.Item>(2) {
+                    imageView {
+                        isVisible()
+                        hasDrawableWithTint(R.drawable.ic_android_black_24dp, android.R.color.holo_red_dark)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sample/src/androidTest/kotlin/com/agoda/sample/screen/DrawableRecyclerScreen.kt
+++ b/sample/src/androidTest/kotlin/com/agoda/sample/screen/DrawableRecyclerScreen.kt
@@ -1,0 +1,21 @@
+package com.agoda.sample.screen
+
+import android.view.View
+import com.agoda.kakao.image.KImageView
+import com.agoda.kakao.recycler.KRecyclerItem
+import com.agoda.kakao.recycler.KRecyclerView
+import com.agoda.kakao.screen.Screen
+import com.agoda.sample.R
+import org.hamcrest.Matcher
+
+class DrawableRecyclerScreen : Screen<DrawableRecyclerScreen>() {
+    val list = KRecyclerView(
+        builder = { withId(R.id.drawableRecycler) },
+        itemTypeBuilder = { itemType(::Item) })
+
+    class Item(parent: Matcher<View>) :
+        KRecyclerItem<Item>(parent) {
+        val imageView = KImageView(parent, { withId(R.id.imgView) })
+    }
+
+}

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -58,6 +58,10 @@
         android:label="Drawable Activity"
         android:theme="@style/AppTheme" />
     <activity
+        android:name=".DrawableRecyclerActivity"
+        android:label="Drawable Activity"
+        android:theme="@style/AppTheme" />
+    <activity
         android:name=".PickersActivity"
         android:label="Pickers Activity"
         android:theme="@style/AppTheme" />

--- a/sample/src/main/kotlin/com/agoda/sample/DrawableRecyclerActivity.kt
+++ b/sample/src/main/kotlin/com/agoda/sample/DrawableRecyclerActivity.kt
@@ -1,0 +1,60 @@
+package com.agoda.sample
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import androidx.annotation.DrawableRes
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+
+class DrawableRecyclerActivity : AppCompatActivity() {
+    val drawableIds = listOf(DrawableResource(R.drawable.ic_android_black_24dp),
+                             DrawableResource(R.drawable.ic_sentiment_very_satisfied_black_24dp),
+                             DrawableResource(R.drawable.ic_android_black_24dp, android.R.color.holo_red_dark))
+
+    val list: RecyclerView by lazy { findViewById<RecyclerView>(R.id.drawableRecycler) }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_drawable_recycler)
+
+        list.layoutManager = LinearLayoutManager(this)
+        list.adapter = object: RecyclerView.Adapter<ViewHolder>() {
+
+            override fun onCreateViewHolder(
+                parent: ViewGroup,
+                viewType: Int
+            ): ViewHolder {
+                val view = LayoutInflater.from(parent.context)
+                    .inflate(R.layout.item_image, parent, false)
+                return ViewHolder(view)
+            }
+
+            override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+                // - get element from your dataset at this position
+                // - replace the contents of the view with that element
+                drawableIds[position].run {
+                    holder.imageView.setImageResource(resId)
+                    tint?.let {
+                        holder.imageView.setColorFilter(
+                            ContextCompat.getColor(holder.imageView.context, it),
+                            android.graphics.PorterDuff.Mode.SRC_IN
+                        )
+                    }
+                }
+            }
+
+            override fun getItemCount() = drawableIds.size
+        }
+    }
+
+    class ViewHolder(val root: View): RecyclerView.ViewHolder(root) {
+        val imageView: ImageView by lazy { root.findViewById<ImageView>(R.id.imgView) }
+    }
+
+    data class DrawableResource(@DrawableRes val resId: Int, val tint: Int? = null)
+}

--- a/sample/src/main/res/layout/activity_drawable_recycler.xml
+++ b/sample/src/main/res/layout/activity_drawable_recycler.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/drawableRecycler"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />


### PR DESCRIPTION
Adding tests based on ListView but using RecyclerView. 
Tests are failing at image verification

Link to #228

```
 Expected: with drawable id 2131165292 or provided instance
 Got: "AppCompatImageView{id=2131230864, res-name=imgView, visibility=VISIBLE, width=1080, height=63, has-focus=false, has-focusable=false, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params=android.widget.FrameLayout$LayoutParams@5602809, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=0.0}"
```