### PR TITLE
in at least androidx.appcompat:appcompat:1.2.0 androidx.appcompat.wid…

### DIFF
--- a/kakao/src/main/kotlin/com/agoda/kakao/common/matchers/ToolbarTitleMatcher.kt
+++ b/kakao/src/main/kotlin/com/agoda/kakao/common/matchers/ToolbarTitleMatcher.kt
@@ -27,6 +27,6 @@ class ToolbarTitleMatcher() : BoundedMatcher<View, Toolbar>(Toolbar::class.java)
         if (title == null && resId != null) {
             title = resId?.let { view?.context?.getString(it) }
         }
-        return view?.title?.toString().equals(title)
+        return view?.title?.toString() == title
     }
 }

--- a/kakao/src/main/kotlin/com/agoda/kakao/common/matchers/ToolbarTitleMatcher.kt
+++ b/kakao/src/main/kotlin/com/agoda/kakao/common/matchers/ToolbarTitleMatcher.kt
@@ -27,6 +27,6 @@ class ToolbarTitleMatcher() : BoundedMatcher<View, Toolbar>(Toolbar::class.java)
         if (title == null && resId != null) {
             title = resId?.let { view?.context?.getString(it) }
         }
-        return view?.title?.equals(title) ?: false
+        return view?.title?.toString().equals(title)
     }
 }


### PR DESCRIPTION
at least in `androidx.appcompat:appcompat:1.2.0 androidx.appcompat.widget.Toolbar#getTitle` returns a `StringBuffer` on API-Level 30 (Samsung). So `toolbar.title` can never be equal with the string `title`. `toString()` fixes that and should also work with other implementations, which return `CharSequence` or `String`.