### PR TITLE
Fix AmbiguousViewMatcherException when offscreenPageLimit is set

### DIFF
--- a/kakao/src/main/kotlin/com/agoda/kakao/pager2/KViewPager2.kt
+++ b/kakao/src/main/kotlin/com/agoda/kakao/pager2/KViewPager2.kt
@@ -3,6 +3,7 @@
 package com.agoda.kakao.pager2
 
 import android.view.View
+import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.DataInteraction
 import androidx.test.espresso.Root
 import androidx.test.espresso.matcher.RootMatchers
@@ -10,6 +11,7 @@ import com.agoda.kakao.common.KakaoDslMarker
 import com.agoda.kakao.common.actions.SwipeableActions
 import com.agoda.kakao.common.assertions.BaseAssertions
 import com.agoda.kakao.common.builders.ViewBuilder
+import com.agoda.kakao.common.matchers.PositionMatcher
 import com.agoda.kakao.delegate.ViewInteractionDelegate
 import org.hamcrest.Matcher
 import kotlin.reflect.KClass
@@ -103,7 +105,13 @@ class KViewPager2 : ViewPager2Actions, ViewPager2AdapterAssertions, SwipeableAct
         } catch (error: Throwable) {
         }
 
-        function(provideItem(matcher) as T).also { inRoot { withMatcher(this@KViewPager2.root) } }
+        val vb = ViewBuilder().apply {
+            isDescendantOfA { withMatcher(this@KViewPager2.matcher) }
+            isInstanceOf(RecyclerView::class.java)
+        }
+
+        function(provideItem(PositionMatcher(vb.getViewMatcher(), position)) as T)
+            .also { inRoot { withMatcher(this@KViewPager2.root) } }
     }
 
     /**

--- a/sample/src/androidTest/kotlin/com/agoda/sample/screen/Pager2Screen.kt
+++ b/sample/src/androidTest/kotlin/com/agoda/sample/screen/Pager2Screen.kt
@@ -16,6 +16,6 @@ open class Pager2Screen : Screen<Pager2Screen>() {
     })
 
     class SimpleItem(parent: Matcher<View>) : KViewPagerItem<SimpleItem>(parent) {
-        val text: KTextView = KTextView { withId(R.id.text) }
+        val text: KTextView = KTextView(parent) { withId(R.id.text) }
     }
 }

--- a/sample/src/main/kotlin/com/agoda/sample/ViewPager2Activity.kt
+++ b/sample/src/main/kotlin/com/agoda/sample/ViewPager2Activity.kt
@@ -18,6 +18,7 @@ class ViewPager2Activity : FragmentActivity() {
         val pager = findViewById<ViewPager2>(R.id.pager)
         val adapter = ScreenSlidePagerAdapter(this, (0..5).map { SimpleFragment(it) })
 
+        pager.offscreenPageLimit = 1
         pager.adapter = adapter
 
     }


### PR DESCRIPTION
This PR resolves an issue that a view matcher in `KViewPager2#childAt` throws `AmbiguousViewMatcherException` because ViewPager2 holds multiple Fragments when `ViewPager2#setOffscreenPageLimit` is used.